### PR TITLE
Use std::mutex rather than std::atomic to protect ads_construction_status

### DIFF
--- a/include/wt/util/gui/gui.hpp
+++ b/include/wt/util/gui/gui.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 
 #include <wt/math/common.hpp>
 #include <wt/bitmap/bitmap.hpp>
@@ -45,7 +46,8 @@ public:
         std::atomic<f_t> scene_loading_progress = 0;
         std::atomic<f_t> resource_loading_progress = 0;
         std::atomic<f_t> ads_construction_progress = 0;
-        std::atomic<std::shared_ptr<std::string>> ads_construction_status;
+        std::shared_ptr<std::string> ads_construction_status;
+        mutable std::mutex ads_construction_status_mutex;
     };
 
 private:

--- a/src/util/gui/gui.cpp
+++ b/src/util/gui/gui.cpp
@@ -1211,8 +1211,11 @@ inline void loading_popup(const gui_t::bootstrap_data_t& bs) {
 
     imgui_loading_progress_bar("Constructing ADS", vec3_t{ .2,.2,1 },
                                bs.ads_construction_progress.load());
-    if (const auto ads_status = bs.ads_construction_status.load(); ads_status)
-        imgui_hover_tooltip(ads_status->c_str());
+    {
+        std::lock_guard<std::mutex> lock(bs.ads_construction_status_mutex);
+        if (const auto ads_status = bs.ads_construction_status; ads_status)
+            imgui_hover_tooltip(ads_status->c_str());
+    }
 
     ImGui::End();
 }


### PR DESCRIPTION
(std::shared_ptr<> is too big for std::atomic and wouldn't compile on OSX.)