### PR TITLE
Work-around deficient OSX std::osyncstream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ set(SRC
 
     src/util/font_renderer.cpp
     src/util/logger.cpp
+    src/util/termcolor.cpp
     src/util/math_expression.cpp
     src/util/preview_tev.cpp
     src/util/tpool.cpp
@@ -417,7 +418,7 @@ endif()
 find_package(PNG)
 find_package(libdeflate CONFIG REQUIRED)
 find_package(OpenEXR CONFIG REQUIRED)
-find_package(Freetype CONFIG REQUIRED)
+find_package(Freetype REQUIRED)
 
 find_package(TBB CONFIG REQUIRED)
 

--- a/include/wt/util/logger/termcolor.hpp
+++ b/include/wt/util/logger/termcolor.hpp
@@ -19,10 +19,16 @@
 #include <cassert>
 #include <cstdint>
 #include <iostream>
+#ifdef __cpp_lib_syncstream
 #include <syncstream>
+#endif
 
 namespace wt::logger {
 
+// Forward declarations
+#ifndef __cpp_lib_syncstream
+class basic_osyncstream;
+#endif
 
 //
 // based on github.com/p-ranav/indicators by Pranav
@@ -383,12 +389,12 @@ inline bool is_atty(const std::ostream& stream) noexcept {
     return ::isatty(fileno(std_stream));
 #endif
 }
-inline bool is_atty(std::osyncstream& stream) noexcept {
-    const auto sb = stream.get_wrapped();
-    if (!sb)
-        return false;
-    return sb==std::cout.rdbuf() || sb==std::cerr.rdbuf() || sb==std::clog.rdbuf();
-}
+// Forward declarations for non-inline functions
+#ifdef __cpp_lib_syncstream
+bool is_atty(std::osyncstream& stream) noexcept;
+#else
+bool is_atty(basic_osyncstream& stream) noexcept;
+#endif
 
 }
 
@@ -408,9 +414,11 @@ inline bool is_colourized(std::ostream& stream) noexcept {
 /**
  * @brief Check if a stream supports coloured output.
  */
-inline bool is_colourized(std::osyncstream& stream) noexcept {
-    return _detail::is_atty(stream);
-}
+#ifdef __cpp_lib_syncstream
+bool is_colourized(std::osyncstream& stream) noexcept;
+#else
+bool is_colourized(basic_osyncstream& stream) noexcept;
+#endif
 
 inline void move_up(std::ostream &os, int lines) noexcept { os << "\033[" << lines << "A"; }
 inline void move_down(std::ostream &os, int lines) noexcept { os << "\033[" << lines << "B"; }

--- a/src/util/logger.cpp
+++ b/src/util/logger.cpp
@@ -18,6 +18,10 @@
 #include <wt/util/logger/progressbar.hpp>
 #include <wt/util/logger/termcolor.hpp>
 
+#ifndef __cpp_lib_syncstream
+std::mutex wt::logger::basic_osyncstream::mutex;
+#endif
+
 
 using namespace wt;
 using namespace logger;

--- a/src/util/termcolor.cpp
+++ b/src/util/termcolor.cpp
@@ -1,0 +1,45 @@
+/*
+*
+* wave tracer
+* Copyright  Shlomi Steinberg
+*
+* LICENSE: Creative Commons Attribution-NonCommercial 4.0 International
+*
+*/
+
+#include <wt/util/logger/logger.hpp>
+#include <wt/util/logger/termcolor.hpp>
+
+namespace wt::logger::termcolour::_detail {
+
+#ifdef __cpp_lib_syncstream
+bool is_atty(std::osyncstream& stream) noexcept {
+    const auto sb = stream.get_wrapped();
+    if (!sb)
+        return false;
+    return sb==std::cout.rdbuf() || sb==std::cerr.rdbuf() || sb==std::clog.rdbuf();
+}
+#else
+bool is_atty(basic_osyncstream& stream) noexcept {
+    const auto sb = stream.get_wrapped();
+    if (!sb)
+        return false;
+    return sb==std::cout.rdbuf() || sb==std::cerr.rdbuf() || sb==std::clog.rdbuf();
+}
+#endif
+
+} // namespace wt::logger::termcolour::_detail
+
+namespace wt::logger::termcolour {
+
+#ifdef __cpp_lib_syncstream
+bool is_colourized(std::osyncstream& stream) noexcept {
+    return _detail::is_atty(stream);
+}
+#else
+bool is_colourized(basic_osyncstream& stream) noexcept {
+    return _detail::is_atty(stream);
+}
+#endif
+
+} // namespace wt::logger::termcolour


### PR DESCRIPTION
Over to you about how you feel about the style-wise, etc.

With this all of the OSX build issues except a bunch related to mp-units should be fixed. (Those may be more of a project to work through but I'll see what I can figure out.)